### PR TITLE
Redesigned some elements

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,4 +112,4 @@ def disconnect():
 
 
 if __name__ == "__main__":
-    socketio.run(app, debug=True)
+    socketio.run(app, debug=True, host="0.0.0.0", port=5000)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -117,11 +117,21 @@
 
 .text {
     margin-bottom: 10px;
+    padding: 10px;
+    border-radius: 5px;
+    background-color: #f1f1f1;
+    border: 1px solid #ccc;
 }
 
 .text span {
     display: inline-block;
     margin-bottom: 5px;
+    text-wrap: wrap;
+    word-break: break-all;
+}
+
+.message-cnt {
+    width: 60%;
 }
 
 .text strong {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -127,7 +127,7 @@
     display: inline-block;
     margin-bottom: 5px;
     text-wrap: wrap;
-    word-break: break-all;
+    word-break: break-word;
 }
 
 .text span p {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -119,7 +119,7 @@
     margin-bottom: 10px;
     padding: 10px;
     border-radius: 5px;
-    background-color: #f1f1f1;
+    background-color: #fdfafa;
     border: 1px solid #ccc;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -130,6 +130,10 @@
     word-break: break-all;
 }
 
+.text span p {
+    margin: 0;
+}
+
 .message-cnt {
     width: 60%;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -53,7 +53,7 @@
     color: white;
     padding: 10px 20px;
     border: none;
-    border-radius: 5px;
+    border-radius: 3px;
     cursor: pointer;
     margin-left: 35px;
     margin-right: 35px;

--- a/templates/room.html
+++ b/templates/room.html
@@ -38,7 +38,8 @@
         const content = `
         <div class="text"> 
             <span class="message-cnt">
-                 <strong> ${name}</strong>: ${msg}
+                 <strong> ${name}</strong>
+                 <p>${msg}</p>
             </span> 
             <span class="muted">
                 ${new Date().toLocaleString()}

--- a/templates/room.html
+++ b/templates/room.html
@@ -37,7 +37,7 @@
     const createMessage = (name, msg) => {
         const content = `
         <div class="text"> 
-            <span>
+            <span class="message-cnt">
                  <strong> ${name}</strong>: ${msg}
             </span> 
             <span class="muted">


### PR DESCRIPTION
This Pull Request introduces several changes to the UI of the app, specifically:

- Now messages look like boxes and follow the format of:
```
USERNAME                          TIMESTAMP
[TEXT]
```
- Fixed the length issue of messages by using the `break-word` property of CSS and `width`. Also added `message-cnt` to the classist of the message content span to allow styling it via CSS easily.
- Added a border and a background color around the messages.
![image](https://github.com/Armancollab/LiveChatRoom/assets/127299159/3648ba9d-3f9c-42a9-b7a3-baf51995f5ca)
- Set the `border-radius` of the homepage buttons to 3px to maintain design consistency (previously 5px).

**Optional**:
Added a host and a port to `socketio.run()` in main.py, because the link with the app was undiscoverable.

Please let me know if you have any questions or would like to change anything!